### PR TITLE
Fix issue #1: Skip secret init but still honoring x3dh message presence

### DIFF
--- a/android/core/src/androidTest/java/id/ridon/ngobrel/core/SesameConversationInstrumentedTest.java
+++ b/android/core/src/androidTest/java/id/ridon/ngobrel/core/SesameConversationInstrumentedTest.java
@@ -108,6 +108,10 @@ public class SesameConversationInstrumentedTest {
     // The encrypted text is uploaded to server. Server then puts it in a mailbox
     serverPutToMailbox(encrypted);
 
+    encrypted = aliceConversation.encrypt(message.getBytes());
+
+    // The encrypted text is uploaded to server. Server then puts it in a mailbox
+    serverPutToMailbox(encrypted);
     // Server then -- in some way -- tells Bob that he has an incoming message
     // Bob then initiates a conversation on his side
     // He does that by downloading Alice's bundle


### PR DESCRIPTION
The bug is about the presence of X3dh message but got skipped because secrets have been initialized.
This patch checks for the presence of the message and even though the secrets are already initialized,
the cipher text message offset is calculated properly.